### PR TITLE
Declare webpack et al as devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/lassediercks/range-slider-sass"
   },
-  "dependencies":{
+  "devDependencies":{
     "bower": "^1.4.1",
     "css-loader": "^0.10.1",
     "json-loader": "^0.5.2",


### PR DESCRIPTION
Not required when using range-slider-sass as a library within another project
